### PR TITLE
Fix: Resolve hydration errors by refactoring data-loading hooks

### DIFF
--- a/hooks/use-addresses.ts
+++ b/hooks/use-addresses.ts
@@ -122,29 +122,31 @@ const generateMockCoordinates = (): { lat: number; lng: number } => {
 }
 
 export function useAddresses() {
-  const [addresses, setAddresses] = useState<Address[]>([])
-  const [routes, setRoutes] = useState<DeliveryRoute[]>([])
-
-  // Load addresses from localStorage
-  useEffect(() => {
-    const savedAddresses = localStorage.getItem("dropflow-addresses")
-    if (savedAddresses) {
-      try {
-        setAddresses(JSON.parse(savedAddresses))
-      } catch (error) {
-        console.error("Error loading addresses:", error)
-      }
+  const [addresses, setAddresses] = useState<Address[]>(() => {
+    if (typeof window === "undefined") {
+      return []
     }
-
-    const savedRoutes = localStorage.getItem("dropflow-routes")
-    if (savedRoutes) {
-      try {
-        setRoutes(JSON.parse(savedRoutes))
-      } catch (error) {
-        console.error("Error loading routes:", error)
-      }
+    try {
+      const savedAddresses = localStorage.getItem("dropflow-addresses")
+      return savedAddresses ? JSON.parse(savedAddresses) : []
+    } catch (error) {
+      console.error("Error loading addresses from localStorage:", error)
+      return []
     }
-  }, [])
+  })
+
+  const [routes, setRoutes] = useState<DeliveryRoute[]>(() => {
+    if (typeof window === "undefined") {
+      return []
+    }
+    try {
+      const savedRoutes = localStorage.getItem("dropflow-routes")
+      return savedRoutes ? JSON.parse(savedRoutes) : []
+    } catch (error) {
+      console.error("Error loading routes from localStorage:", error)
+      return []
+    }
+  })
 
   // Save addresses to localStorage
   const saveAddresses = (newAddresses: Address[]) => {

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -58,32 +58,35 @@ const MOCK_USERS = [
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null)
   const [isLoading, setIsLoading] = useState(true)
-  const [isClient, setIsClient] = useState(false)
 
   useEffect(() => {
-    setIsClient(true)
+    try {
+      const storedUser = localStorage.getItem("dropflow-user")
+      if (storedUser) {
+        setUser(JSON.parse(storedUser))
+      }
+    } catch (error) {
+      console.error("Failed to load user from localStorage", error)
+      setUser(null)
+    } finally {
+      setIsLoading(false)
+    }
   }, [])
 
   // Mock API delay to simulate real API calls
   const mockDelay = (ms = 500) => new Promise((resolve) => setTimeout(resolve, ms))
 
   const checkAuth = async () => {
-    if (!isClient) return
-
+    // This function is now deprecated. The logic is handled by the useEffect above.
+    // It is kept for now to avoid breaking the context signature.
+    setIsLoading(true)
     try {
-      setIsLoading(true)
-      await mockDelay(300) // Simulate API call delay
-
-      // Check if user is stored in localStorage (mock session)
       const storedUser = localStorage.getItem("dropflow-user")
       if (storedUser) {
-        const userData = JSON.parse(storedUser)
-        setUser(userData)
-      } else {
-        setUser(null)
+        setUser(JSON.parse(storedUser))
       }
     } catch (error) {
-      console.log("No active session found")
+      console.error("checkAuth failed:", error)
       setUser(null)
     } finally {
       setIsLoading(false)
@@ -221,12 +224,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setUser(null)
     }
   }
-
-  useEffect(() => {
-    if (isClient) {
-      checkAuth()
-    }
-  }, [isClient])
 
   const value = {
     user,


### PR DESCRIPTION
This commit addresses a critical client-side exception caused by hydration errors in the application's data-loading hooks.

The `useAddresses` and `useAuth` hooks were loading data from `localStorage` inside a `useEffect` after an initial render with empty state. This created a mismatch between the server-rendered and client-rendered UI, causing a fatal hydration error.

- Refactored the `useAddresses` hook to use a `useState` initializer function. This is the correct pattern for safely loading client-side data, as it populates the state during the initial client render, preventing the mismatch.
- Refactored the `useAuth` hook to use a safe `useEffect` hook that runs only once on mount to load the user session. This simplifies the logic and also prevents hydration errors.

These changes ensure the application loads data from `localStorage` in a way that is safe for server-side rendering frameworks like Next.js, resolving the root cause of the application crashes and improving overall stability.