### PR TITLE
Fix: Prevent crash on 'Continue to Route' button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -248,7 +248,7 @@ export default function DropFlowApp() {
 
         {currentView === "home" && (
           <>
-            {hasActiveDelivery && (
+            {hasActiveDelivery && activeRoute && (
               <div className="mb-6">
                 <DeliveryProgress
                   stops={stops}

--- a/components/delivery-progress.tsx
+++ b/components/delivery-progress.tsx
@@ -32,6 +32,11 @@ export function DeliveryProgress({
   className = "",
   onNavigateToRoute,
 }: DeliveryProgressProps) {
+  // Guard against inconsistent state where stops are active but there's no route.
+  if (!activeRoute && stops.some((s) => s.status === "pending")) {
+    return null
+  }
+
   const [currentTime, setCurrentTime] = useState(new Date())
   const [estimatedCompletion, setEstimatedCompletion] = useState<Date | null>(null)
   const [trafficAwareETA, setTrafficAwareETA] = useState<string | null>(null)


### PR DESCRIPTION
Resolves a race condition that caused a crash when clicking the 'Continue to Route' banner on the dashboard.

The `DeliveryProgress` component could render with active stops but without a corresponding `activeRoute` object, leading to a null reference error.

This has been fixed by:
- Adding a guard clause to `delivery-progress.tsx` to prevent rendering in this inconsistent state.
- Strengthening the display logic in `app/page.tsx` to only show the banner when both `stops` and `activeRoute` are confirmed to be loaded.