### PR TITLE
Fix delivery route map integration

### DIFF
--- a/components/MapView.web.tsx
+++ b/components/MapView.web.tsx
@@ -150,3 +150,5 @@ const MapView: React.FC<MapViewProps> = ({ stops }) => {
 }
 
 export default MapView
+
+export { MapView }

--- a/components/route-planner.tsx
+++ b/components/route-planner.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { MapView } from "@/components/MapView.web"
+import MapView from "@/components/MapView.web"
 import { DeliveryProgress } from "@/components/delivery-progress"
 import { useAddresses } from "@/hooks/use-addresses"
 


### PR DESCRIPTION
## Summary
- import the web MapView component correctly in the route planner so the Google Map renders
- expose both default and named exports from MapView.web.tsx to support existing imports

## Testing
- pnpm lint *(fails: prompts for ESLint configuration and exits)*

------
https://chatgpt.com/codex/tasks/task_e_68da0ab98dd8832bbb87a2d602b47bca