### PR TITLE
Add Expo-based React Native mobile app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+mobile/node_modules

--- a/README.md
+++ b/README.md
@@ -28,3 +28,27 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## React Native mobile app
+
+A standalone Expo project lives in [`mobile/`](mobile/) and mirrors the web experience for managing DropFlow routes. It ships with
+demo data, offline persistence, and the same authentication flows used on the web.
+
+### Getting started
+
+```bash
+cd mobile
+npm install
+npm run start
+```
+
+Then use the Expo QR code to open the native app on iOS or Android (or run `npm run android` / `npm run ios` with an attached
+simulator).
+
+### Features
+
+- Shared authentication mock (demo@dropflow.com / demo123)
+- Address management with automatic corrections and validation
+- Route planning with multi-select and active run tracking
+- Delivery plan workspace with stop reordering, progress, and notes
+- Local persistence via AsyncStorage and one-tap demo reset

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,29 @@
+{
+  "expo": {
+    "name": "DropFlow Mobile",
+    "slug": "dropflow-mobile",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "scheme": "dropflow",
+    "userInterfaceStyle": "automatic",
+    "splash": {
+      "backgroundColor": "#ffffff"
+    },
+    "assetBundlePatterns": ["**/*"],
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "com.dropflow.app"
+    },
+    "android": {
+      "package": "com.dropflow.app",
+      "versionCode": 1
+    },
+    "web": {
+      "output": "static"
+    },
+    "plugins": ["expo-router"],
+    "experiments": {
+      "typedRoutes": true
+    }
+  }
+}

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,0 +1,37 @@
+import { Tabs } from "expo-router"
+import { Ionicons } from "@expo/vector-icons"
+import { useAuth } from "@/hooks/useAuth"
+
+export default function TabsLayout() {
+  const { user } = useAuth()
+
+  return (
+    <Tabs
+      screenOptions={({ route }) => ({
+        headerStyle: { backgroundColor: "#0f172a" },
+        headerTintColor: "white",
+        tabBarStyle: { backgroundColor: "#0f172a", borderTopColor: "#1f2937" },
+        tabBarActiveTintColor: "#ef4444",
+        tabBarInactiveTintColor: "#9ca3af",
+        tabBarIcon: ({ color, size }) => {
+          const iconMap: Record<string, keyof typeof Ionicons.glyphMap> = {
+            home: "home-outline",
+            addresses: "navigate-outline",
+            routes: "map-outline",
+            plan: "list-outline",
+            profile: "person-circle-outline",
+          }
+          const iconName = iconMap[route.name] ?? "ellipse-outline"
+          return <Ionicons name={iconName} color={color} size={size} />
+        },
+        headerTitle: route.name === "home" ? `Welcome${user ? `, ${user.firstName ?? user.email}` : ""}` : undefined,
+      })}
+    >
+      <Tabs.Screen name="home" options={{ title: "Overview" }} />
+      <Tabs.Screen name="addresses" options={{ title: "Addresses" }} />
+      <Tabs.Screen name="routes" options={{ title: "Routes" }} />
+      <Tabs.Screen name="plan" options={{ title: "Delivery Plan" }} />
+      <Tabs.Screen name="profile" options={{ title: "Profile" }} />
+    </Tabs>
+  )
+}

--- a/mobile/app/(tabs)/addresses.tsx
+++ b/mobile/app/(tabs)/addresses.tsx
@@ -1,0 +1,250 @@
+import { useMemo, useState } from "react"
+import { View, Text, StyleSheet, TextInput, TouchableOpacity, FlatList, Alert } from "react-native"
+import { useDelivery } from "@/hooks/useDelivery"
+import { autoCorrectAddress, validateAddress } from "@/utils/address"
+import { format } from "date-fns"
+
+export default function AddressesScreen() {
+  const { addresses, addAddress, removeAddress, isReady } = useDelivery()
+  const [address, setAddress] = useState("")
+  const [description, setDescription] = useState("")
+  const [errors, setErrors] = useState<string[]>([])
+  const [isSaving, setSaving] = useState(false)
+
+  const sortedAddresses = useMemo(
+    () => [...addresses].sort((a, b) => new Date(b.dateAdded).getTime() - new Date(a.dateAdded).getTime()),
+    [addresses],
+  )
+
+  const handleAdd = async () => {
+    setErrors([])
+    if (!address.trim()) {
+      setErrors(["Address is required"])
+      return
+    }
+
+    const validation = validateAddress(address)
+    if (!validation.isValid) {
+      setErrors(validation.errors)
+      return
+    }
+
+    setSaving(true)
+    try {
+      await addAddress({ address: validation.corrected, description: description.trim() })
+      setAddress("")
+      setDescription("")
+    } catch (error: any) {
+      setErrors([error.message ?? "Failed to save address"])
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const confirmDelete = (id: string) => {
+    Alert.alert("Remove address", "Are you sure you want to delete this saved address?", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: () => removeAddress(id),
+      },
+    ])
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Add a delivery stop</Text>
+        <Text style={styles.description}>Addresses are auto-corrected and synced to every route.</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="742 Evergreen Terrace"
+          placeholderTextColor="#6b7280"
+          value={address}
+          onChangeText={(value) => {
+            setAddress(value)
+            setErrors([])
+          }}
+          editable={!isSaving && isReady}
+        />
+        <TextInput
+          style={[styles.input, styles.textArea]}
+          placeholder="Notes (gate codes, preferred contact, delivery instructions)"
+          placeholderTextColor="#6b7280"
+          value={description}
+          onChangeText={setDescription}
+          editable={!isSaving && isReady}
+          multiline
+          numberOfLines={3}
+        />
+        {address ? (
+          <Text style={styles.suggestion}>Suggested: {autoCorrectAddress(address)}</Text>
+        ) : null}
+        {errors.length > 0 && (
+          <View style={styles.errorBox}>
+            {errors.map((error) => (
+              <Text key={error} style={styles.errorText}>
+                • {error}
+              </Text>
+            ))}
+          </View>
+        )}
+        <TouchableOpacity
+          style={[styles.button, (!isReady || isSaving) && styles.buttonDisabled]}
+          onPress={handleAdd}
+          disabled={!isReady || isSaving}
+        >
+          <Text style={styles.buttonText}>{isSaving ? "Saving..." : "Save address"}</Text>
+        </TouchableOpacity>
+      </View>
+
+      <FlatList
+        data={sortedAddresses}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={{ paddingBottom: 120 }}
+        ListHeaderComponent={() => (
+          <Text style={styles.sectionTitle}>Saved addresses</Text>
+        )}
+        renderItem={({ item }) => (
+          <View style={styles.addressCard}>
+            <View style={{ flex: 1, gap: 4 }}>
+              <Text style={styles.address}>{item.address}</Text>
+              {item.description ? <Text style={styles.notes}>{item.description}</Text> : null}
+              <Text style={styles.meta}>{`Added ${format(new Date(item.dateAdded), "MMM d, yyyy")}`}</Text>
+              <Text style={styles.meta}>{`Used in ${item.timesUsed} routes`}</Text>
+            </View>
+            <TouchableOpacity style={styles.deleteButton} onPress={() => confirmDelete(item.id)}>
+              <Text style={styles.deleteText}>Remove</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+        ListEmptyComponent={() => (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyTitle}>No saved addresses yet</Text>
+            <Text style={styles.emptyText}>Add a location above to start building optimized delivery routes.</Text>
+          </View>
+        )}
+      />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+    padding: 16,
+  },
+  card: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    gap: 12,
+    marginBottom: 20,
+  },
+  title: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  description: {
+    color: "#9ca3af",
+  },
+  input: {
+    backgroundColor: "#1f2937",
+    color: "white",
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#374151",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  textArea: {
+    height: 96,
+    textAlignVertical: "top",
+  },
+  suggestion: {
+    color: "#9ca3af",
+    fontSize: 12,
+  },
+  button: {
+    backgroundColor: "#ef4444",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: "white",
+    fontWeight: "600",
+  },
+  sectionTitle: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "600",
+    marginBottom: 12,
+  },
+  addressCard: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    marginBottom: 12,
+  },
+  address: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  notes: {
+    color: "#d1d5db",
+  },
+  meta: {
+    color: "#9ca3af",
+    fontSize: 12,
+  },
+  deleteButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#b91c1c",
+  },
+  deleteText: {
+    color: "#fca5a5",
+    fontWeight: "600",
+  },
+  emptyState: {
+    alignItems: "center",
+    padding: 48,
+    gap: 8,
+  },
+  emptyTitle: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  emptyText: {
+    color: "#9ca3af",
+    textAlign: "center",
+  },
+  errorBox: {
+    backgroundColor: "#7f1d1d",
+    borderRadius: 10,
+    padding: 12,
+    gap: 4,
+  },
+  errorText: {
+    color: "#fecaca",
+    fontSize: 12,
+  },
+})

--- a/mobile/app/(tabs)/home.tsx
+++ b/mobile/app/(tabs)/home.tsx
@@ -1,0 +1,222 @@
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from "react-native"
+import { useRouter } from "expo-router"
+import { useDelivery } from "@/hooks/useDelivery"
+import { useAuth } from "@/hooks/useAuth"
+import { format } from "date-fns"
+
+export default function HomeScreen() {
+  const router = useRouter()
+  const { addresses, routes, activeRoute, activeStops, isReady } = useDelivery()
+  const { user } = useAuth()
+
+  if (!isReady) {
+    return (
+      <View style={styles.loading}>
+        <Text style={{ color: "white" }}>Preparing your workspace…</Text>
+      </View>
+    )
+  }
+
+  const completedStops = activeStops.filter((stop) => stop.status === "completed").length
+  const pendingStops = activeStops.filter((stop) => stop.status === "pending").length
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={{ paddingBottom: 48 }}>
+      <Text style={styles.heading}>DropFlow overview</Text>
+
+      <View style={styles.cardGrid}>
+        <SummaryCard
+          title="Saved addresses"
+          value={String(addresses.length)}
+          subtitle="Optimized and ready for route planning"
+          onPress={() => router.push("/(tabs)/addresses")}
+        />
+        <SummaryCard
+          title="Delivery routes"
+          value={String(routes.length)}
+          subtitle="Draft, active, and completed"
+          onPress={() => router.push("/(tabs)/routes")}
+        />
+        <SummaryCard
+          title="Active stops"
+          value={String(activeStops.length)}
+          subtitle={activeRoute ? `${completedStops} done • ${pendingStops} remaining` : "Start a route to begin"}
+          onPress={() => router.push("/(tabs)/plan")}
+        />
+      </View>
+
+      {activeRoute ? (
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Currently running</Text>
+          <Text style={styles.cardValue}>{activeRoute.name}</Text>
+          <Text style={styles.cardMeta}>
+            {format(new Date(activeRoute.createdAt), "MMM d, yyyy • h:mm a")} • {activeStops.length} stops
+          </Text>
+          <View style={styles.progressRow}>
+            <View style={[styles.progressBar, { flex: activeStops.length ? completedStops : 1 }]} />
+            <View style={[styles.progressBarPending, { flex: pendingStops }]} />
+          </View>
+          <View style={styles.buttonRow}>
+            <TouchableOpacity style={[styles.primaryButton]} onPress={() => router.push("/(tabs)/plan")}>
+              <Text style={styles.primaryButtonText}>Open delivery plan</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      ) : (
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>No active delivery</Text>
+          <Text style={styles.cardMeta}>Build a route to launch your next run.</Text>
+          <View style={styles.buttonRow}>
+            <TouchableOpacity style={styles.primaryButton} onPress={() => router.push("/(tabs)/routes")}>
+              <Text style={styles.primaryButtonText}>Plan new route</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.secondaryButton} onPress={() => router.push("/(tabs)/addresses")}>
+              <Text style={styles.secondaryButtonText}>Manage addresses</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
+
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>Account</Text>
+        <Text style={styles.cardMeta}>{user ? `Signed in as ${user.email}` : "Guest session"}</Text>
+        <TouchableOpacity style={styles.secondaryButton} onPress={() => router.push("/(tabs)/profile")}>
+          <Text style={styles.secondaryButtonText}>Profile & settings</Text>
+        </TouchableOpacity>
+      </View>
+    </ScrollView>
+  )
+}
+
+function SummaryCard({
+  title,
+  value,
+  subtitle,
+  onPress,
+}: {
+  title: string
+  value: string
+  subtitle: string
+  onPress: () => void
+}) {
+  return (
+    <TouchableOpacity style={styles.summaryCard} onPress={onPress}>
+      <Text style={styles.summaryValue}>{value}</Text>
+      <Text style={styles.summaryTitle}>{title}</Text>
+      <Text style={styles.summarySubtitle}>{subtitle}</Text>
+    </TouchableOpacity>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+    padding: 16,
+  },
+  heading: {
+    color: "white",
+    fontSize: 24,
+    fontWeight: "700",
+    marginBottom: 16,
+  },
+  cardGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+  summaryCard: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    width: "100%",
+  },
+  summaryValue: {
+    color: "#ef4444",
+    fontSize: 32,
+    fontWeight: "700",
+  },
+  summaryTitle: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "600",
+    marginTop: 8,
+  },
+  summarySubtitle: {
+    color: "#9ca3af",
+    marginTop: 4,
+  },
+  card: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    marginTop: 16,
+    gap: 8,
+  },
+  cardTitle: {
+    color: "#9ca3af",
+    fontSize: 14,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  cardValue: {
+    color: "white",
+    fontSize: 20,
+    fontWeight: "600",
+  },
+  cardMeta: {
+    color: "#9ca3af",
+  },
+  progressRow: {
+    flexDirection: "row",
+    height: 8,
+    borderRadius: 9999,
+    overflow: "hidden",
+    backgroundColor: "#1f2937",
+    marginTop: 12,
+  },
+  progressBar: {
+    backgroundColor: "#ef4444",
+  },
+  progressBarPending: {
+    backgroundColor: "#374151",
+  },
+  buttonRow: {
+    flexDirection: "row",
+    gap: 12,
+    marginTop: 12,
+    flexWrap: "wrap",
+  },
+  primaryButton: {
+    backgroundColor: "#ef4444",
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 12,
+  },
+  primaryButtonText: {
+    color: "white",
+    fontWeight: "600",
+  },
+  secondaryButton: {
+    backgroundColor: "transparent",
+    borderWidth: 1,
+    borderColor: "#374151",
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 12,
+  },
+  secondaryButtonText: {
+    color: "#e5e7eb",
+    fontWeight: "500",
+  },
+  loading: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+})

--- a/mobile/app/(tabs)/plan.tsx
+++ b/mobile/app/(tabs)/plan.tsx
@@ -1,0 +1,293 @@
+import { useMemo, useState, useEffect } from "react"
+import { View, Text, StyleSheet, TouchableOpacity, FlatList, TextInput, Alert } from "react-native"
+import { useDelivery } from "@/hooks/useDelivery"
+
+export default function PlanScreen() {
+  const { activeRoute, activeStops, updateStopStatus, reorderStops, completeRoute, isReady } = useDelivery()
+  const [selectedStopId, setSelectedStopId] = useState<string | null>(null)
+  const [note, setNote] = useState("")
+
+  const currentStop = useMemo(() => activeStops.find((stop) => stop.id === selectedStopId), [activeStops, selectedStopId])
+
+  useEffect(() => {
+    if (currentStop) {
+      setNote(currentStop.notes ?? "")
+    } else {
+      setNote("")
+    }
+  }, [currentStop?.id, currentStop?.notes])
+
+  const handleComplete = () => {
+    Alert.alert("Complete delivery", "Mark this route as finished?", [
+      { text: "Cancel", style: "cancel" },
+      { text: "Complete", style: "destructive", onPress: completeRoute },
+    ])
+  }
+
+  if (!isReady) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.info}>Loading plan...</Text>
+      </View>
+    )
+  }
+
+  if (!activeRoute) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>No active route</Text>
+        <Text style={styles.info}>Start a route from the Routes tab to manage deliveries.</Text>
+      </View>
+    )
+  }
+
+  const pending = activeStops.filter((stop) => stop.status === "pending").length
+  const completed = activeStops.filter((stop) => stop.status === "completed").length
+  const skipped = activeStops.filter((stop) => stop.status === "skipped").length
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>{activeRoute.name}</Text>
+        <Text style={styles.info}>{activeStops.length} stops • {completed} completed • {pending} remaining</Text>
+        {skipped > 0 && <Text style={styles.warning}>{skipped} skipped</Text>}
+        <TouchableOpacity
+          style={[styles.primaryButton, pending > 0 && styles.disabledButton]}
+          onPress={handleComplete}
+          disabled={pending > 0}
+        >
+          <Text style={styles.primaryButtonText}>Mark route complete</Text>
+        </TouchableOpacity>
+      </View>
+
+      <FlatList
+        data={activeStops}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={{ paddingBottom: 120 }}
+        ListHeaderComponent={<Text style={styles.sectionTitle}>Stops</Text>}
+        renderItem={({ item, index }) => (
+          <TouchableOpacity
+            style={[styles.stopCard, item.status !== "pending" && styles.stopCardCompleted, selectedStopId === item.id && styles.stopCardSelected]}
+            onPress={() => {
+              setSelectedStopId(item.id)
+              setNote(item.notes ?? "")
+            }}
+          >
+            <View style={{ flex: 1, gap: 4 }}>
+              <Text style={styles.stopOrder}>#{index + 1}</Text>
+              <Text style={styles.stopAddress}>{item.address}</Text>
+              {item.notes ? <Text style={styles.stopNotes}>{item.notes}</Text> : null}
+              <Text style={[styles.status, styles[`status${capitalize(item.status)}` as const]]}>{capitalize(item.status)}</Text>
+            </View>
+            <View style={styles.stopActions}>
+              <TouchableOpacity style={styles.moveButton} onPress={() => reorderStops(index, Math.max(0, index - 1))}>
+                <Text style={styles.moveButtonText}>↑</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.moveButton}
+                onPress={() => reorderStops(index, Math.min(activeStops.length - 1, index + 1))}
+              >
+                <Text style={styles.moveButtonText}>↓</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.statusButton, styles.statusButtonCompleted]}
+                onPress={() => updateStopStatus(item.id, "completed")}
+              >
+                <Text style={styles.statusButtonText}>Done</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={[styles.statusButton, styles.statusButtonPending]} onPress={() => updateStopStatus(item.id, "pending")}>
+                <Text style={styles.statusButtonText}>Reset</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={[styles.statusButton, styles.statusButtonSkipped]} onPress={() => updateStopStatus(item.id, "skipped")}>
+                <Text style={styles.statusButtonText}>Skip</Text>
+              </TouchableOpacity>
+            </View>
+          </TouchableOpacity>
+        )}
+        ListEmptyComponent={() => (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyTitle}>No stops loaded</Text>
+            <Text style={styles.emptyText}>Routes need at least one address before you can start them.</Text>
+          </View>
+        )}
+      />
+
+      {currentStop ? (
+        <View style={styles.notesCard}>
+          <Text style={styles.sectionTitle}>Notes for {currentStop.address}</Text>
+          <TextInput
+            style={styles.notesInput}
+            placeholder="Proof of delivery, access notes, etc."
+            placeholderTextColor="#6b7280"
+            value={note}
+            onChangeText={setNote}
+            multiline
+            numberOfLines={3}
+          />
+          <TouchableOpacity
+            style={styles.primaryButton}
+            onPress={() => updateStopStatus(currentStop.id, currentStop.status, note.trim() || undefined)}
+          >
+            <Text style={styles.primaryButtonText}>Save note</Text>
+          </TouchableOpacity>
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1)
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+    padding: 16,
+  },
+  card: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    gap: 8,
+  },
+  title: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  info: {
+    color: "#9ca3af",
+  },
+  warning: {
+    color: "#fde68a",
+  },
+  primaryButton: {
+    backgroundColor: "#ef4444",
+    paddingVertical: 12,
+    borderRadius: 12,
+    alignItems: "center",
+    marginTop: 8,
+  },
+  primaryButtonText: {
+    color: "white",
+    fontWeight: "600",
+  },
+  disabledButton: {
+    opacity: 0.5,
+  },
+  sectionTitle: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "600",
+    marginVertical: 16,
+  },
+  stopCard: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    marginBottom: 12,
+    flexDirection: "row",
+    gap: 12,
+  },
+  stopCardCompleted: {
+    borderColor: "#16a34a",
+  },
+  stopCardSelected: {
+    borderColor: "#3b82f6",
+  },
+  stopOrder: {
+    color: "#9ca3af",
+    fontWeight: "600",
+  },
+  stopAddress: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  stopNotes: {
+    color: "#d1d5db",
+  },
+  stopActions: {
+    gap: 6,
+    alignItems: "flex-end",
+  },
+  moveButton: {
+    backgroundColor: "#1f2937",
+    borderRadius: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  moveButtonText: {
+    color: "#e5e7eb",
+    fontWeight: "700",
+  },
+  statusButton: {
+    borderRadius: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  statusButtonCompleted: {
+    backgroundColor: "#16a34a",
+  },
+  statusButtonPending: {
+    backgroundColor: "#374151",
+  },
+  statusButtonSkipped: {
+    backgroundColor: "#f59e0b",
+  },
+  statusButtonText: {
+    color: "white",
+    fontWeight: "600",
+  },
+  status: {
+    marginTop: 4,
+    fontWeight: "600",
+  },
+  statusPending: {
+    color: "#fde68a",
+  },
+  statusCompleted: {
+    color: "#bbf7d0",
+  },
+  statusSkipped: {
+    color: "#fbbf24",
+  },
+  emptyState: {
+    alignItems: "center",
+    padding: 48,
+    gap: 8,
+  },
+  emptyTitle: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  emptyText: {
+    color: "#9ca3af",
+    textAlign: "center",
+  },
+  notesCard: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    gap: 12,
+    marginBottom: 24,
+  },
+  notesInput: {
+    backgroundColor: "#1f2937",
+    color: "white",
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#374151",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    minHeight: 96,
+    textAlignVertical: "top",
+  },
+})

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -1,0 +1,85 @@
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from "react-native"
+import { useAuth } from "@/hooks/useAuth"
+import { useDelivery } from "@/hooks/useDelivery"
+
+export default function ProfileScreen() {
+  const { user, logout } = useAuth()
+  const { resetDemoData } = useDelivery()
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={{ paddingBottom: 120 }}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Account</Text>
+        <Text style={styles.meta}>{user ? user.email : "Guest"}</Text>
+        {user?.firstName || user?.lastName ? (
+          <Text style={styles.meta}>{[user?.firstName, user?.lastName].filter(Boolean).join(" ")}</Text>
+        ) : null}
+        <TouchableOpacity style={styles.primaryButton} onPress={logout}>
+          <Text style={styles.primaryText}>Sign out</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.title}>Demo data</Text>
+        <Text style={styles.meta}>Restore the seeded addresses, routes, and stops.</Text>
+        <TouchableOpacity style={styles.secondaryButton} onPress={resetDemoData}>
+          <Text style={styles.secondaryText}>Reset demo content</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.title}>About</Text>
+        <Text style={styles.meta}>
+          DropFlow Mobile keeps your delivery planning available offline. Routes and authentication are stored securely on your
+          device using AsyncStorage.
+        </Text>
+      </View>
+    </ScrollView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+    padding: 16,
+  },
+  card: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    gap: 12,
+    marginBottom: 16,
+  },
+  title: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  meta: {
+    color: "#9ca3af",
+  },
+  primaryButton: {
+    backgroundColor: "#ef4444",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  primaryText: {
+    color: "white",
+    fontWeight: "600",
+  },
+  secondaryButton: {
+    borderWidth: 1,
+    borderColor: "#374151",
+    paddingVertical: 12,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  secondaryText: {
+    color: "#e5e7eb",
+    fontWeight: "600",
+  },
+})

--- a/mobile/app/(tabs)/routes.tsx
+++ b/mobile/app/(tabs)/routes.tsx
@@ -1,0 +1,286 @@
+import { useMemo, useState } from "react"
+import { View, Text, StyleSheet, TextInput, TouchableOpacity, FlatList, Switch } from "react-native"
+import { format } from "date-fns"
+import { useDelivery } from "@/hooks/useDelivery"
+
+export default function RoutesScreen() {
+  const { routes, addresses, createRoute, deleteRoute, startRoute, activeRoute, isReady } = useDelivery()
+  const [routeName, setRouteName] = useState("")
+  const [selectedAddressIds, setSelectedAddressIds] = useState<string[]>([])
+  const [isCreating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const sortedRoutes = useMemo(
+    () => [...routes].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+    [routes],
+  )
+
+  const toggleAddress = (id: string) => {
+    setSelectedAddressIds((prev) => (prev.includes(id) ? prev.filter((addrId) => addrId !== id) : [...prev, id]))
+  }
+
+  const handleCreate = async () => {
+    setError(null)
+    if (!routeName.trim()) {
+      setError("Route name is required")
+      return
+    }
+    if (selectedAddressIds.length === 0) {
+      setError("Select at least one address")
+      return
+    }
+
+    setCreating(true)
+    try {
+      await createRoute({
+        name: routeName.trim(),
+        addressIds: selectedAddressIds,
+      })
+      setRouteName("")
+      setSelectedAddressIds([])
+    } catch (error: any) {
+      setError(error.message ?? "Unable to create route")
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Build a delivery route</Text>
+        <Text style={styles.description}>Select the stops to include and DropFlow will keep them synced.</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Morning run"
+          placeholderTextColor="#6b7280"
+          value={routeName}
+          onChangeText={setRouteName}
+          editable={!isCreating && isReady}
+        />
+        <View style={styles.addressList}>
+          {addresses.length === 0 ? (
+            <Text style={styles.emptyAddresses}>Add addresses first to create a route.</Text>
+          ) : (
+            addresses.map((address) => (
+              <View key={address.id} style={styles.addressRow}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.address}>{address.address}</Text>
+                  {address.description ? <Text style={styles.notes}>{address.description}</Text> : null}
+                </View>
+                <Switch value={selectedAddressIds.includes(address.id)} onValueChange={() => toggleAddress(address.id)} />
+              </View>
+            ))
+          )}
+        </View>
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+        <TouchableOpacity
+          style={[styles.button, (!isReady || isCreating || selectedAddressIds.length === 0) && styles.buttonDisabled]}
+          onPress={handleCreate}
+          disabled={!isReady || isCreating || selectedAddressIds.length === 0}
+        >
+          <Text style={styles.buttonText}>{isCreating ? "Creating..." : "Create route"}</Text>
+        </TouchableOpacity>
+      </View>
+
+      <FlatList
+        data={sortedRoutes}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={{ paddingBottom: 120 }}
+        ListHeaderComponent={<Text style={styles.sectionTitle}>Your routes</Text>}
+        renderItem={({ item }) => {
+          const isActive = activeRoute?.id === item.id
+          return (
+            <View style={[styles.routeCard, isActive && styles.routeCardActive]}>
+              <View style={{ flex: 1, gap: 4 }}>
+                <Text style={styles.routeName}>{item.name}</Text>
+                <Text style={styles.meta}>{format(new Date(item.createdAt), "MMM d, yyyy • h:mm a")}</Text>
+                <Text style={styles.meta}>{`${item.addresses.length} stops`}</Text>
+                <Text style={[styles.status, styles[`status${capitalize(item.status)}` as const]]}>{capitalize(item.status)}</Text>
+                <View style={{ gap: 2 }}>
+                  {item.addresses.map((address) => (
+                    <Text key={address.id} style={styles.stop}>
+                      • {address.address}
+                    </Text>
+                  ))}
+                </View>
+              </View>
+              <View style={styles.routeActions}>
+                <TouchableOpacity style={styles.secondaryButton} onPress={() => deleteRoute(item.id)}>
+                  <Text style={styles.secondaryText}>Delete</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.primaryButton, (!isReady || item.addresses.length === 0) && styles.buttonDisabled]}
+                  onPress={() => startRoute(item.id)}
+                  disabled={!isReady || item.addresses.length === 0}
+                >
+                  <Text style={styles.buttonText}>{isActive ? "Resume" : "Start"}</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          )
+        }}
+        ListEmptyComponent={() => (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyTitle}>No routes yet</Text>
+            <Text style={styles.emptyText}>Create your first route above to begin planning deliveries.</Text>
+          </View>
+        )}
+      />
+    </View>
+  )
+}
+
+const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slice(1)
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+    padding: 16,
+  },
+  card: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    gap: 12,
+    marginBottom: 20,
+  },
+  title: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  description: {
+    color: "#9ca3af",
+  },
+  input: {
+    backgroundColor: "#1f2937",
+    color: "white",
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#374151",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  addressList: {
+    gap: 12,
+  },
+  addressRow: {
+    backgroundColor: "#1f2937",
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#374151",
+    padding: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  address: {
+    color: "white",
+    fontWeight: "600",
+  },
+  notes: {
+    color: "#d1d5db",
+  },
+  emptyAddresses: {
+    color: "#9ca3af",
+    fontStyle: "italic",
+  },
+  error: {
+    color: "#fca5a5",
+  },
+  button: {
+    backgroundColor: "#ef4444",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  buttonText: {
+    color: "white",
+    fontWeight: "600",
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  sectionTitle: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "600",
+    marginBottom: 12,
+  },
+  routeCard: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    marginBottom: 12,
+    flexDirection: "row",
+    gap: 12,
+  },
+  routeCardActive: {
+    borderColor: "#ef4444",
+  },
+  routeName: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  meta: {
+    color: "#9ca3af",
+  },
+  status: {
+    fontWeight: "600",
+    marginTop: 8,
+  },
+  statusDraft: {
+    color: "#9ca3af",
+  },
+  statusActive: {
+    color: "#fde68a",
+  },
+  statusCompleted: {
+    color: "#bbf7d0",
+  },
+  stop: {
+    color: "#d1d5db",
+  },
+  routeActions: {
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+  },
+  primaryButton: {
+    backgroundColor: "#ef4444",
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    borderRadius: 10,
+  },
+  secondaryButton: {
+    borderWidth: 1,
+    borderColor: "#374151",
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+  },
+  secondaryText: {
+    color: "#e5e7eb",
+    fontWeight: "500",
+  },
+  emptyState: {
+    alignItems: "center",
+    padding: 48,
+    gap: 8,
+  },
+  emptyTitle: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  emptyText: {
+    color: "#9ca3af",
+    textAlign: "center",
+  },
+})

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,0 +1,39 @@
+import { Stack } from "expo-router"
+import { SplashScreen } from "expo-router"
+import { useEffect, useState } from "react"
+import { SafeAreaProvider } from "react-native-safe-area-context"
+import { GestureHandlerRootView } from "react-native-gesture-handler"
+import { AuthProvider } from "@/contexts/AuthContext"
+import { DeliveryProvider } from "@/contexts/DeliveryContext"
+
+SplashScreen.preventAutoHideAsync()
+
+export default function RootLayout() {
+  const [isReady, setReady] = useState(false)
+
+  useEffect(() => {
+    setReady(true)
+  }, [])
+
+  useEffect(() => {
+    if (isReady) {
+      SplashScreen.hideAsync()
+    }
+  }, [isReady])
+
+  if (!isReady) {
+    return null
+  }
+
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <SafeAreaProvider>
+        <AuthProvider>
+          <DeliveryProvider>
+            <Stack screenOptions={{ headerShown: false }} />
+          </DeliveryProvider>
+        </AuthProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
+  )
+}

--- a/mobile/app/auth.tsx
+++ b/mobile/app/auth.tsx
@@ -1,0 +1,244 @@
+import { useState } from "react"
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, KeyboardAvoidingView, Platform, ScrollView } from "react-native"
+import { Link, router } from "expo-router"
+import { useAuth } from "@/hooks/useAuth"
+
+export default function AuthScreen() {
+  const { login, register, isInitializing } = useAuth()
+  const [mode, setMode] = useState<"login" | "register">("login")
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [firstName, setFirstName] = useState("")
+  const [lastName, setLastName] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [info, setInfo] = useState<string | null>(null)
+  const [isSubmitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async () => {
+    setError(null)
+    setInfo(null)
+
+    if (!email.trim() || !password.trim()) {
+      setError("Email and password are required")
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      if (mode === "login") {
+        const result = await login(email.trim().toLowerCase(), password)
+        if (!result.success) {
+          setError(result.message)
+          return
+        }
+        router.replace("/(tabs)/home")
+      } else {
+        const result = await register({
+          email: email.trim().toLowerCase(),
+          password,
+          firstName: firstName.trim(),
+          lastName: lastName.trim(),
+        })
+        if (!result.success) {
+          setError(result.message)
+          return
+        }
+        setInfo(result.message)
+        router.replace("/(tabs)/home")
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === "ios" ? "padding" : undefined}>
+      <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+        <View style={styles.card}>
+          <Text style={styles.title}>Welcome to DropFlow</Text>
+          <View style={styles.switchRow}>
+            <TouchableOpacity
+              style={[styles.switchButton, mode === "login" && styles.switchButtonActive]}
+              onPress={() => setMode("login")}
+              disabled={isSubmitting}
+            >
+              <Text style={[styles.switchButtonText, mode === "login" && styles.switchButtonTextActive]}>Login</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.switchButton, mode === "register" && styles.switchButtonActive]}
+              onPress={() => setMode("register")}
+              disabled={isSubmitting}
+            >
+              <Text style={[styles.switchButtonText, mode === "register" && styles.switchButtonTextActive]}>Register</Text>
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.formGroup}>
+            <Text style={styles.label}>Email</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="you@example.com"
+              placeholderTextColor="#9ca3af"
+              autoCapitalize="none"
+              autoComplete="email"
+              keyboardType="email-address"
+              value={email}
+              onChangeText={setEmail}
+              editable={!isSubmitting && !isInitializing}
+            />
+          </View>
+
+          {mode === "register" && (
+            <>
+              <View style={styles.formGroup}>
+                <Text style={styles.label}>First name</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="Jane"
+                  placeholderTextColor="#9ca3af"
+                  value={firstName}
+                  onChangeText={setFirstName}
+                  editable={!isSubmitting && !isInitializing}
+                />
+              </View>
+              <View style={styles.formGroup}>
+                <Text style={styles.label}>Last name</Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="Doe"
+                  placeholderTextColor="#9ca3af"
+                  value={lastName}
+                  onChangeText={setLastName}
+                  editable={!isSubmitting && !isInitializing}
+                />
+              </View>
+            </>
+          )}
+
+          <View style={styles.formGroup}>
+            <Text style={styles.label}>Password</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="••••••••"
+              placeholderTextColor="#9ca3af"
+              secureTextEntry
+              value={password}
+              onChangeText={setPassword}
+              editable={!isSubmitting && !isInitializing}
+            />
+          </View>
+
+          {error && <Text style={styles.error}>{error}</Text>}
+          {info && <Text style={styles.info}>{info}</Text>}
+
+          <TouchableOpacity
+            style={[styles.primaryButton, isSubmitting && styles.primaryButtonDisabled]}
+            onPress={handleSubmit}
+            disabled={isSubmitting}
+          >
+            <Text style={styles.primaryButtonText}>{mode === "login" ? "Sign in" : "Create account"}</Text>
+          </TouchableOpacity>
+
+          <Text style={styles.helper}>Use demo@dropflow.com / demo123 to explore instantly.</Text>
+
+          <Link href="/(tabs)/home" asChild>
+            <TouchableOpacity>
+              <Text style={styles.link}>Skip for now</Text>
+            </TouchableOpacity>
+          </Link>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    justifyContent: "center",
+    padding: 24,
+    backgroundColor: "#0f172a",
+  },
+  card: {
+    backgroundColor: "#111827",
+    borderRadius: 16,
+    padding: 24,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    gap: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "600",
+    color: "white",
+    textAlign: "center",
+  },
+  switchRow: {
+    flexDirection: "row",
+    backgroundColor: "#1f2937",
+    borderRadius: 12,
+    padding: 4,
+  },
+  switchButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 10,
+  },
+  switchButtonActive: {
+    backgroundColor: "#ef4444",
+  },
+  switchButtonText: {
+    color: "#9ca3af",
+    textAlign: "center",
+    fontWeight: "500",
+  },
+  switchButtonTextActive: {
+    color: "white",
+  },
+  formGroup: {
+    gap: 6,
+  },
+  label: {
+    color: "#d1d5db",
+    fontSize: 14,
+  },
+  input: {
+    backgroundColor: "#1f2937",
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    color: "white",
+    borderWidth: 1,
+    borderColor: "#374151",
+  },
+  primaryButton: {
+    backgroundColor: "#ef4444",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  primaryButtonDisabled: {
+    opacity: 0.6,
+  },
+  primaryButtonText: {
+    color: "white",
+    fontWeight: "600",
+    fontSize: 16,
+  },
+  error: {
+    color: "#fca5a5",
+    textAlign: "center",
+  },
+  info: {
+    color: "#a7f3d0",
+    textAlign: "center",
+  },
+  helper: {
+    color: "#9ca3af",
+    textAlign: "center",
+  },
+  link: {
+    textAlign: "center",
+    color: "#60a5fa",
+  },
+})

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -1,0 +1,21 @@
+import { Redirect } from "expo-router"
+import { View, ActivityIndicator } from "react-native"
+import { useAuth } from "@/hooks/useAuth"
+
+export default function Index() {
+  const { user, isInitializing } = useAuth()
+
+  if (isInitializing) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: "#111827" }}>
+        <ActivityIndicator color="#ef4444" size="large" />
+      </View>
+    )
+  }
+
+  if (!user) {
+    return <Redirect href="/auth" />
+  }
+
+  return <Redirect href="/(tabs)/home" />
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,9 @@
+module.exports = function (api) {
+  api.cache(true)
+  return {
+    presets: ["babel-preset-expo"],
+    plugins: [
+      require.resolve("expo-router/babel"),
+    ],
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "dropflow-mobile",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web",
+    "lint": "expo lint"
+  },
+  "dependencies": {
+    "@expo/vector-icons": "^14.0.2",
+    "@react-native-async-storage/async-storage": "^1.23.1",
+    "date-fns": "^3.6.0",
+    "expo": "^51.0.0",
+    "expo-linking": "^6.3.1",
+    "expo-router": "^3.5.21",
+    "expo-secure-store": "^13.0.2",
+    "expo-status-bar": "^1.11.2",
+    "react": "18.2.0",
+    "react-native": "0.74.3",
+    "react-native-gesture-handler": "^2.20.2",
+    "react-native-safe-area-context": "^4.10.5",
+    "react-native-screens": "^3.32.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.7",
+    "@types/react": "18.2.47",
+    "@types/react-native": "0.73.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/mobile/src/constants/demo.ts
+++ b/mobile/src/constants/demo.ts
@@ -1,0 +1,35 @@
+import { Address, DeliveryRoute } from "@/types"
+
+export const DEMO_ADDRESSES: Address[] = [
+  {
+    id: "addr-1",
+    address: "123 Market Street, Sydney NSW 2000",
+    description: "Loading dock via Kent St",
+    dateAdded: new Date().toISOString(),
+    timesUsed: 5,
+  },
+  {
+    id: "addr-2",
+    address: "55 Collins Street, Melbourne VIC 3000",
+    description: "Deliver before 11am",
+    dateAdded: new Date().toISOString(),
+    timesUsed: 4,
+  },
+  {
+    id: "addr-3",
+    address: "88 Adelaide Terrace, Perth WA 6000",
+    description: "Call ahead for access",
+    dateAdded: new Date().toISOString(),
+    timesUsed: 3,
+  },
+]
+
+export const DEMO_ROUTES: DeliveryRoute[] = [
+  {
+    id: "route-1",
+    name: "Sydney CBD Morning Run",
+    addresses: [DEMO_ADDRESSES[0]],
+    createdAt: new Date().toISOString(),
+    status: "draft",
+  },
+]

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -1,0 +1,174 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
+import AsyncStorage from "@react-native-async-storage/async-storage"
+import { Alert } from "react-native"
+import { User } from "@/types"
+
+interface StoredUser extends User {
+  password: string
+}
+
+interface RegisterPayload {
+  email: string
+  password: string
+  firstName?: string
+  lastName?: string
+}
+
+interface AuthContextValue {
+  user: User | null
+  isInitializing: boolean
+  login: (email: string, password: string) => Promise<{ success: boolean; message: string }>
+  register: (payload: RegisterPayload) => Promise<{ success: boolean; message: string }>
+  logout: () => Promise<void>
+}
+
+const USERS_KEY = "dropflow-mobile-users"
+const SESSION_KEY = "dropflow-mobile-session"
+
+const DEMO_USERS: StoredUser[] = [
+  {
+    id: "user-1",
+    email: "demo@dropflow.com",
+    password: "demo123",
+    firstName: "Demo",
+    lastName: "Courier",
+    isVerified: true,
+    isPremium: false,
+  },
+  {
+    id: "user-2",
+    email: "premium@dropflow.com",
+    password: "premium123",
+    firstName: "Premium",
+    lastName: "Courier",
+    isVerified: true,
+    isPremium: true,
+  },
+]
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null)
+  const [users, setUsers] = useState<StoredUser[]>(DEMO_USERS)
+  const [isInitializing, setIsInitializing] = useState(true)
+
+  useEffect(() => {
+    const bootstrap = async () => {
+      try {
+        const [storedUsers, storedSession] = await Promise.all([
+          AsyncStorage.getItem(USERS_KEY),
+          AsyncStorage.getItem(SESSION_KEY),
+        ])
+
+        if (storedUsers) {
+          setUsers(JSON.parse(storedUsers))
+        } else {
+          await AsyncStorage.setItem(USERS_KEY, JSON.stringify(DEMO_USERS))
+        }
+
+        if (storedSession) {
+          const parsed = JSON.parse(storedSession) as User
+          setUser(parsed)
+        }
+      } catch (error) {
+        console.warn("Auth bootstrap failed", error)
+        setUser(null)
+      } finally {
+        setIsInitializing(false)
+      }
+    }
+
+    bootstrap()
+  }, [])
+
+  useEffect(() => {
+    if (!isInitializing) {
+      AsyncStorage.setItem(USERS_KEY, JSON.stringify(users)).catch((error) =>
+        console.warn("Failed to persist users", error),
+      )
+    }
+  }, [users, isInitializing])
+
+  const persistSession = useCallback((sessionUser: User | null) => {
+    if (sessionUser) {
+      AsyncStorage.setItem(SESSION_KEY, JSON.stringify(sessionUser)).catch((error) =>
+        console.warn("Failed to persist session", error),
+      )
+    } else {
+      AsyncStorage.removeItem(SESSION_KEY).catch((error) =>
+        console.warn("Failed to clear session", error),
+      )
+    }
+  }, [])
+
+  const login = useCallback(async (email: string, password: string) => {
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    const normalized = email.trim().toLowerCase()
+    const match = users.find((stored) => stored.email === normalized && stored.password === password)
+
+    if (!match) {
+      return { success: false, message: "Invalid email or password" }
+    }
+
+    const { password: _password, ...safeUser } = match
+    setUser(safeUser)
+    persistSession(safeUser)
+    return { success: true, message: "Signed in" }
+  }, [persistSession, users])
+
+  const register = useCallback(async ({ email, password, firstName, lastName }: RegisterPayload) => {
+    await new Promise((resolve) => setTimeout(resolve, 600))
+    const normalized = email.trim().toLowerCase()
+    const exists = users.some((stored) => stored.email === normalized)
+
+    if (exists) {
+      return { success: false, message: "An account already exists for this email" }
+    }
+
+    const newUser: StoredUser = {
+      id: `user-${Date.now()}`,
+      email: normalized,
+      password,
+      firstName: firstName?.trim() || undefined,
+      lastName: lastName?.trim() || undefined,
+      isVerified: true,
+      isPremium: false,
+    }
+
+    setUsers((current) => [...current, newUser])
+    const { password: _password, ...safeUser } = newUser
+    setUser(safeUser)
+    persistSession(safeUser)
+
+    Alert.alert("Account created", "A verified DropFlow account was created locally for demo purposes.")
+
+    return { success: true, message: "Account created" }
+  }, [persistSession, users])
+
+  const logout = useCallback(async () => {
+    setUser(null)
+    persistSession(null)
+  }, [persistSession])
+
+  const value = useMemo(
+    () => ({
+      user,
+      isInitializing,
+      login,
+      register,
+      logout,
+    }),
+    [user, isInitializing, login, register, logout],
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export const useAuthContext = () => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error("useAuthContext must be used within AuthProvider")
+  }
+  return context
+}

--- a/mobile/src/contexts/DeliveryContext.tsx
+++ b/mobile/src/contexts/DeliveryContext.tsx
@@ -1,0 +1,328 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
+import AsyncStorage from "@react-native-async-storage/async-storage"
+import { Address, DeliveryRoute, DeliveryStop, StopStatus } from "@/types"
+import { DEMO_ADDRESSES, DEMO_ROUTES } from "@/constants/demo"
+
+interface DeliveryContextValue {
+  isReady: boolean
+  addresses: Address[]
+  routes: DeliveryRoute[]
+  activeRoute: DeliveryRoute | null
+  activeStops: DeliveryStop[]
+  addAddress: (payload: { address: string; description?: string }) => Promise<void>
+  removeAddress: (addressId: string) => Promise<void>
+  createRoute: (payload: { name: string; addressIds: string[] }) => Promise<void>
+  deleteRoute: (routeId: string) => Promise<void>
+  startRoute: (routeId: string) => Promise<void>
+  updateStopStatus: (stopId: string, status: StopStatus, notes?: string) => Promise<void>
+  reorderStops: (fromIndex: number, toIndex: number) => void
+  completeRoute: () => Promise<void>
+  resetDemoData: () => Promise<void>
+}
+
+interface PersistedState {
+  addresses: Address[]
+  routes: DeliveryRoute[]
+  activeRouteId: string | null
+  activeStops: DeliveryStop[]
+}
+
+const STORAGE_KEY = "dropflow-mobile-delivery"
+
+const DeliveryContext = createContext<DeliveryContextValue | null>(null)
+
+const generateDemoState = (): PersistedState => {
+  const now = Date.now()
+  const addresses: Address[] = DEMO_ADDRESSES.map((address, index) => ({
+    ...address,
+    id: `${address.id}-${now}-${index}`,
+    dateAdded: new Date().toISOString(),
+  }))
+  const addressLookup = new Map(DEMO_ADDRESSES.map((address, index) => [address.id, addresses[index]]))
+  const routes: DeliveryRoute[] = DEMO_ROUTES.map((route, index) => ({
+    ...route,
+    id: `${route.id}-${now}-${index}`,
+    createdAt: new Date().toISOString(),
+    status: "draft",
+    addresses: route.addresses
+      .map((addr) => addressLookup.get(addr.id))
+      .filter((addr): addr is Address => Boolean(addr)),
+  }))
+  return {
+    addresses,
+    routes,
+    activeRouteId: null,
+    activeStops: [],
+  }
+}
+
+export const DeliveryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, setState] = useState<PersistedState>(() => ({ addresses: [], routes: [], activeRouteId: null, activeStops: [] }))
+  const [isReady, setIsReady] = useState(false)
+
+  useEffect(() => {
+    const bootstrap = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STORAGE_KEY)
+        if (stored) {
+          const parsed = JSON.parse(stored) as PersistedState
+          setState(parsed)
+        } else {
+          const demo = generateDemoState()
+          setState(demo)
+          await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(demo))
+        }
+      } catch (error) {
+        console.warn("Failed to load delivery state", error)
+        setState(generateDemoState())
+      } finally {
+        setIsReady(true)
+      }
+    }
+
+    bootstrap()
+  }, [])
+
+  useEffect(() => {
+    if (isReady) {
+      AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(state)).catch((error) =>
+        console.warn("Failed to persist delivery state", error),
+      )
+    }
+  }, [state, isReady])
+
+  const activeRoute = useMemo(
+    () => (state.activeRouteId ? state.routes.find((route) => route.id === state.activeRouteId) ?? null : null),
+    [state.routes, state.activeRouteId],
+  )
+
+  const addAddress = useCallback(async ({ address, description }: { address: string; description?: string }) => {
+    setState((current) => {
+      const newAddress: Address = {
+        id: `addr-${Date.now()}`,
+        address,
+        description: description?.trim() || undefined,
+        dateAdded: new Date().toISOString(),
+        timesUsed: 0,
+      }
+      return {
+        ...current,
+        addresses: [newAddress, ...current.addresses],
+      }
+    })
+  }, [])
+
+  const removeAddress = useCallback(async (addressId: string) => {
+    setState((current) => {
+      const addresses = current.addresses.filter((address) => address.id !== addressId)
+      const routes = current.routes.map((route) => ({
+        ...route,
+        addresses: route.addresses.filter((address) => address.id !== addressId),
+        status: route.addresses.filter((address) => address.id !== addressId).length === 0 ? "draft" : route.status,
+      }))
+      const activeStops = current.activeStops.filter((stop) => stop.addressId !== addressId)
+      const activeRouteId = activeStops.length > 0 ? current.activeRouteId : null
+      return {
+        addresses,
+        routes,
+        activeStops,
+        activeRouteId,
+      }
+    })
+  }, [])
+
+  const createRoute = useCallback(async ({ name, addressIds }: { name: string; addressIds: string[] }) => {
+    setState((current) => {
+      const selected = addressIds
+        .map((id) => current.addresses.find((address) => address.id === id))
+        .filter((address): address is Address => Boolean(address))
+
+      if (selected.length === 0) {
+        return current
+      }
+
+      const newRoute: DeliveryRoute = {
+        id: `route-${Date.now()}`,
+        name,
+        createdAt: new Date().toISOString(),
+        status: "draft",
+        addresses: selected.map((address) => ({ ...address })),
+      }
+
+      return {
+        ...current,
+        routes: [newRoute, ...current.routes],
+      }
+    })
+  }, [])
+
+  const deleteRoute = useCallback(async (routeId: string) => {
+    setState((current) => {
+      const routes = current.routes.filter((route) => route.id !== routeId)
+      const isActive = current.activeRouteId === routeId
+      return {
+        ...current,
+        routes,
+        activeRouteId: isActive ? null : current.activeRouteId,
+        activeStops: isActive ? [] : current.activeStops,
+      }
+    })
+  }, [])
+
+  const startRoute = useCallback(async (routeId: string) => {
+    setState((current) => {
+      const target = current.routes.find((route) => route.id === routeId)
+      if (!target || target.addresses.length === 0) {
+        return current
+      }
+
+      const stops: DeliveryStop[] = target.addresses.map((address, index) => ({
+        id: `${routeId}-${address.id}-${index}`,
+        addressId: address.id,
+        address: address.address,
+        status: "pending",
+        notes: undefined,
+      }))
+
+      const routes = current.routes.map((route) =>
+        route.id === routeId
+          ? { ...route, status: "active" }
+          : route.status === "active"
+            ? { ...route, status: "draft" }
+            : route,
+      )
+
+      const addresses = current.addresses.map((address) =>
+        target.addresses.some((selected) => selected.id === address.id)
+          ? { ...address, timesUsed: address.timesUsed + 1 }
+          : address,
+      )
+
+      return {
+        addresses,
+        routes,
+        activeRouteId: routeId,
+        activeStops: stops,
+      }
+    })
+  }, [])
+
+  const updateStopStatus = useCallback(async (stopId: string, status: StopStatus, notes?: string) => {
+    setState((current) => {
+      const activeStops = current.activeStops.map((stop) =>
+        stop.id === stopId
+          ? {
+              ...stop,
+              status,
+              notes: notes ?? stop.notes,
+            }
+          : stop,
+      )
+
+      const allCompleted = activeStops.length > 0 && activeStops.every((stop) => stop.status === "completed")
+      const routes = allCompleted && current.activeRouteId
+        ? current.routes.map((route) =>
+            route.id === current.activeRouteId ? { ...route, status: "completed" } : route,
+          )
+        : current.routes
+
+      return {
+        ...current,
+        activeStops,
+        routes,
+      }
+    })
+  }, [])
+
+  const reorderStops = useCallback((fromIndex: number, toIndex: number) => {
+    setState((current) => {
+      if (
+        fromIndex === toIndex ||
+        fromIndex < 0 ||
+        toIndex < 0 ||
+        fromIndex >= current.activeStops.length ||
+        toIndex >= current.activeStops.length
+      ) {
+        return current
+      }
+
+      const updated = [...current.activeStops]
+      const [moved] = updated.splice(fromIndex, 1)
+      updated.splice(toIndex, 0, moved)
+
+      return {
+        ...current,
+        activeStops: updated,
+      }
+    })
+  }, [])
+
+  const completeRoute = useCallback(async () => {
+    setState((current) => {
+      if (!current.activeRouteId) {
+        return current
+      }
+
+      const routes = current.routes.map((route) =>
+        route.id === current.activeRouteId ? { ...route, status: "completed" } : route,
+      )
+
+      return {
+        ...current,
+        routes,
+        activeRouteId: null,
+        activeStops: [],
+      }
+    })
+  }, [])
+
+  const resetDemoData = useCallback(async () => {
+    const demo = generateDemoState()
+    setState(demo)
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      isReady,
+      addresses: state.addresses,
+      routes: state.routes,
+      activeRoute,
+      activeStops: state.activeStops,
+      addAddress,
+      removeAddress,
+      createRoute,
+      deleteRoute,
+      startRoute,
+      updateStopStatus,
+      reorderStops,
+      completeRoute,
+      resetDemoData,
+    }),
+    [
+      isReady,
+      state.addresses,
+      state.routes,
+      state.activeStops,
+      activeRoute,
+      addAddress,
+      removeAddress,
+      createRoute,
+      deleteRoute,
+      startRoute,
+      updateStopStatus,
+      reorderStops,
+      completeRoute,
+      resetDemoData,
+    ],
+  )
+
+  return <DeliveryContext.Provider value={value}>{children}</DeliveryContext.Provider>
+}
+
+export const useDeliveryContext = () => {
+  const context = useContext(DeliveryContext)
+  if (!context) {
+    throw new Error("useDeliveryContext must be used within DeliveryProvider")
+  }
+  return context
+}

--- a/mobile/src/hooks/useAuth.ts
+++ b/mobile/src/hooks/useAuth.ts
@@ -1,0 +1,3 @@
+import { useAuthContext } from "@/contexts/AuthContext"
+
+export const useAuth = () => useAuthContext()

--- a/mobile/src/hooks/useDelivery.ts
+++ b/mobile/src/hooks/useDelivery.ts
@@ -1,0 +1,3 @@
+import { useDeliveryContext } from "@/contexts/DeliveryContext"
+
+export const useDelivery = () => useDeliveryContext()

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -1,0 +1,40 @@
+export type StopStatus = "pending" | "completed" | "skipped"
+
+export interface Address {
+  id: string
+  address: string
+  description?: string
+  dateAdded: string
+  timesUsed: number
+  coordinates?: { lat: number; lng: number }
+}
+
+export interface DeliveryRoute {
+  id: string
+  name: string
+  addresses: Address[]
+  createdAt: string
+  status: "draft" | "active" | "completed"
+}
+
+export interface DeliveryStop {
+  id: string
+  addressId: string
+  address: string
+  notes?: string
+  status: StopStatus
+}
+
+export interface User {
+  id: string
+  email: string
+  firstName?: string
+  lastName?: string
+  isVerified: boolean
+  isPremium?: boolean
+}
+
+export interface AuthResponse {
+  success: boolean
+  message: string
+}

--- a/mobile/src/utils/address.ts
+++ b/mobile/src/utils/address.ts
@@ -1,0 +1,77 @@
+const corrections: Record<string, string> = {
+  " st ": " street ",
+  " st,": " street,",
+  " st$": " street",
+  " ave ": " avenue ",
+  " ave,": " avenue,",
+  " ave$": " avenue",
+  " rd ": " road ",
+  " rd,": " road,",
+  " rd$": " road",
+  " dr ": " drive ",
+  " dr,": " drive,",
+  " dr$": " drive",
+  " blvd ": " boulevard ",
+  " blvd,": " boulevard,",
+  " blvd$": " boulevard",
+  " ln ": " lane ",
+  " ln,": " lane,",
+  " ln$": " lane",
+  " ct ": " court ",
+  " ct,": " court,",
+  " ct$": " court",
+  " pl ": " place ",
+  " pl,": " place,",
+  " pl$": " place",
+  " cres ": " crescent ",
+  " cres,": " crescent,",
+  " cres$": " crescent",
+  " pde ": " parade ",
+  " pde,": " parade,",
+  " pde$": " parade",
+  " hwy ": " highway ",
+  " hwy,": " highway,",
+  " hwy$": " highway",
+  " tce ": " terrace ",
+  " tce,": " terrace,",
+  " tce$": " terrace",
+}
+
+export const autoCorrectAddress = (input: string): string => {
+  let corrected = input.trim().replace(/\s+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase())
+  Object.entries(corrections).forEach(([key, value]) => {
+    const pattern = key
+      .replace(" ", "\\s+")
+      .replace(",", "\\,")
+      .replace("$", "\\b")
+    const regex = new RegExp(pattern, "gi")
+    corrected = corrected.replace(regex, value)
+  })
+  return corrected
+}
+
+export const validateAddress = (
+  input: string,
+): { isValid: boolean; corrected: string; errors: string[] } => {
+  const corrected = autoCorrectAddress(input)
+  const errors: string[] = []
+
+  if (corrected.length < 5) {
+    errors.push("Address too short")
+  }
+  if (!/\d/.test(corrected)) {
+    errors.push("Include a street number")
+  }
+  if (!/[a-zA-Z]/.test(corrected)) {
+    errors.push("Include a street name")
+  }
+  if (!/(street|road|avenue|drive|lane|boulevard|terrace|parade|court|place|highway)/i.test(corrected)) {
+    errors.push("Add a street type (Street, Avenue, Road, etc.)")
+  }
+
+  return {
+    isValid: errors.length === 0,
+    corrected,
+    errors,
+  }
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "moduleResolution": "node",
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "types": ["expo-router"],
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["src/components/*"],
+      "@/contexts/*": ["src/contexts/*"],
+      "@/hooks/*": ["src/hooks/*"],
+      "@/lib/*": ["src/lib/*"],
+      "@/types": ["src/types"],
+      "@/utils/*": ["src/utils/*"],
+      "@/theme": ["src/theme"],
+      "@/constants/*": ["src/constants/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone Expo React Native project under `mobile/` that mirrors the DropFlow web experience
- implement local auth and delivery state providers with AsyncStorage persistence plus seeded demo content
- build tabbed screens for overview, addresses, routes, delivery plan, and profile and document the new workflow in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f2ee9244fc832b9d524d4b1a55c523